### PR TITLE
Add flip card hover effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,10 +125,54 @@
       box-shadow: 0 2px 8px rgba(0,0,0,0.05);
     }
 
-    .gallery-card img {
+    .gallery-card {
+      perspective: 1000px;
+    }
+
+    .flip-card-inner {
+      position: relative;
       width: 100%;
-      border-radius: 6px;
+      padding-top: 140%;
+      transition: transform 0.6s;
+      transform-style: preserve-3d;
       margin-bottom: 10px;
+    }
+
+    .gallery-card:hover .flip-card-inner {
+      transform: rotateY(180deg);
+    }
+
+    .flip-card-front,
+    .flip-card-back {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      backface-visibility: hidden;
+      border-radius: 6px;
+      overflow: hidden;
+    }
+
+    .flip-card-front {
+      transform: rotateY(180deg);
+    }
+
+    .flip-card-front img,
+    .flip-card-back img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+
+    .flip-card-back {
+      background: #356abc;
+      color: #ffcb05;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: 700;
+      font-size: 1.2rem;
     }
 
     .reviews-carousel {
@@ -234,15 +278,30 @@
     <h2>📸 Featured Sets Gallery</h2>
     <div class="gallery-grid">
       <div class="gallery-card">
-        <img src="https://images.pokemontcg.io/base1/1_hires.png" alt="Base Set Charizard">
+        <div class="flip-card-inner">
+          <div class="flip-card-back">Pokémon</div>
+          <div class="flip-card-front">
+            <img src="https://images.pokemontcg.io/base1/1_hires.png" alt="Base Set Charizard">
+          </div>
+        </div>
         <p><strong>Base Set</strong> — The holy grail of Pokémon investing.</p>
       </div>
       <div class="gallery-card">
-        <img src="https://images.pokemontcg.io/neo1/1_hires.png" alt="Neo Genesis Lugia">
+        <div class="flip-card-inner">
+          <div class="flip-card-back">Pokémon</div>
+          <div class="flip-card-front">
+            <img src="https://images.pokemontcg.io/neo1/1_hires.png" alt="Neo Genesis Lugia">
+          </div>
+        </div>
         <p><strong>Neo Genesis</strong> — Iconic second-gen collector’s dream.</p>
       </div>
       <div class="gallery-card">
-        <img src="https://images.pokemontcg.io/swsh45/SWSH077_hires.png" alt="Modern Promo Pikachu">
+        <div class="flip-card-inner">
+          <div class="flip-card-back">Pokémon</div>
+          <div class="flip-card-front">
+            <img src="https://images.pokemontcg.io/swsh45/SWSH077_hires.png" alt="Modern Promo Pikachu">
+          </div>
+        </div>
         <p><strong>Modern Promos</strong> — Low entry price with viral upside.</p>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- show card backs in Featured Sets gallery
- flip on hover to reveal the fronts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846538182d08325994fc549d5de30da