### PR TITLE
Add animated price chart background

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,6 +112,22 @@
       text-align: center;
     }
 
+    .comparison {
+      background-color: #e9ecef;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .chart-background {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      pointer-events: none;
+      opacity: 0.25;
+    }
+
     .comparison-grid, .gallery-grid {
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
@@ -307,6 +323,17 @@
   </header>
 
   <section class="comparison" data-aos="fade-up">
+    <svg class="chart-background" viewBox="0 0 300 200" preserveAspectRatio="none">
+      <!-- animated price line and moving indicator -->
+      <line x1="40" y1="160" x2="40" y2="20" stroke="#999" stroke-width="2" />
+      <line x1="40" y1="160" x2="280" y2="160" stroke="#999" stroke-width="2" />
+      <path id="price-line" d="M40 160 L80 140 L120 150 L160 110 L200 120 L240 80 L280 40" fill="none" stroke="#2a75bb" stroke-width="2" />
+      <circle r="4" fill="#2a75bb">
+        <animateMotion dur="8s" repeatCount="indefinite" rotate="auto">
+          <mpath xlink:href="#price-line" />
+        </animateMotion>
+      </circle>
+    </svg>
     <h2>📈 10-Year Investment Growth Comparison</h2>
     <div class="comparison-grid">
       <div class="comparison-item">


### PR DESCRIPTION
## Summary
- add a new background animation to the 10‑Year Investment Growth Comparison
- style the comparison section to allow an overlaid SVG

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684658bc24488325a7529b3a86f62c60